### PR TITLE
Refresh Token이 없을 때 에러 로그 레벨 낮추기

### DIFF
--- a/src/main/java/com/be/parrotalk/login/controller/AuthController.java
+++ b/src/main/java/com/be/parrotalk/login/controller/AuthController.java
@@ -31,8 +31,15 @@ public class AuthController {
 
             return ResponseEntity.ok("Access token refreshed successfully.");
         } catch (IllegalArgumentException e) {
-            log.error("Invalid request: ", e);
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+            if ("Refresh token not found.".equals(e.getMessage())) {
+                log.info("익명 사용자 요청: Refresh Token이 없습니다.");
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                        .body("Anonymous user. Refresh Token not found.");
+            } else {
+                // 다른 IllegalArgumentException의 경우 기존 처리
+                log.error("Invalid request: ", e);
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+            }
         } catch (Exception e) {
             log.error("Error while refreshing access token: ", e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("An error occurred.");


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - Refresh Token이 없을 때 에러 로그 레벨 낮추기
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. 새 패키지가 설치되었다면 여기에 반드시 명시해 주세요. -->
  - 익명 유저의 경우 access 요청에 에러가 뜰 수 밖에 없다. (refresh 토큰을 가지고 있지 않기 때문에)
  - 로그인 전에 access 요청이 가는 경우에도 refresh 토큰을 가지고 있지 않아 에러가 발생한다.
  - 에러 로그가 뜨는 게 거슬리기 때문에 `log.error` 에서 `log.info` 수준으로 에러 로그 레벨을 낮추었다.
 ## 📊 테스트 결과 <!-- 테스트 결과를 간단히 적어주시거나 스크린샷을 첨부해 주세요 -->
  
<img width="1308" alt="image" src="https://github.com/user-attachments/assets/3f65b82f-c684-43da-8cb1-62fd92a52f0a" />

 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
  -
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
  - 